### PR TITLE
changing iteritems to items (python 3)

### DIFF
--- a/rest_framework_social_oauth2/views.py
+++ b/rest_framework_social_oauth2/views.py
@@ -35,7 +35,7 @@ class ConvertTokenView(CsrfExemptMixin, OAuthLibMixin, APIView):
 
         # Use the rest framework `.data` to fake the post body of the django request.
         request._request.POST = request._request.POST.copy()
-        for key, value in request.data.iteritems():
+        for key, value in request.data.items():
             request._request.POST[key] = value
 
         url, headers, body, status = self.create_token_response(request._request)


### PR DESCRIPTION
Fixing issue:

QueryDict Object has no attribute 'iteritems' #38

https://github.com/PhilipGarnero/django-rest-framework-social-oauth2/issues/38
